### PR TITLE
[Feature] Adding new haltOnSevereError option

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,3 +48,10 @@ Type: `String`
 Default: `'eslint/lib/formatters/stylish'`
 
 Path path to a custom formatter (See [eslint/tree/master/lib/formatters](https://github.com/eslint/eslint/tree/master/lib/formatters) for alternatives).
+
+##### haltOnSevereError
+
+Type: `Boolean`
+Default: `true`
+
+Determines if eslint should stop linting after encountering a severe error or continue linting.

--- a/lib/index.js
+++ b/lib/index.js
@@ -50,7 +50,8 @@ var EslintValidationFilter = function(inputTree, options) {
     this.options = {
         format: options.format ? options.format : undefined,
         rulesdir: options.rulesdir ? options.rulesdir : undefined,
-        config: options.config ? options.config : './node_modules/eslint/conf/eslint.json'
+        config: options.config ? options.config : './node_modules/eslint/conf/eslint.json',
+        haltOnSevereError: options.haltOnSevereError ? options.haltOnSevereError : true, // Default is set to true
     };
 
     // set formatter
@@ -94,7 +95,7 @@ EslintValidationFilter.prototype.processString = function (content, relativePath
         // log formatter output
         console.log(this.formatter(messages, config));
 
-        if (getResultSeverity(result, config) > 0) {
+        if (getResultSeverity(result, config) > 0 && this.options.haltOnSevereError) {
             // throw error if severe messages exist
             throw 'severe rule errors';
         }

--- a/lib/index.js
+++ b/lib/index.js
@@ -51,7 +51,7 @@ var EslintValidationFilter = function(inputTree, options) {
         format: options.format ? options.format : undefined,
         rulesdir: options.rulesdir ? options.rulesdir : undefined,
         config: options.config ? options.config : './node_modules/eslint/conf/eslint.json',
-        haltOnSevereError: options.haltOnSevereError ? options.haltOnSevereError : true, // Default is set to true
+        haltOnSevereError: (typeof options.haltOnSevereError === 'boolean') ? options.haltOnSevereError : true, // Default is set to true
     };
 
     // set formatter


### PR DESCRIPTION
Adding a new option called: haltOnSevereError which allows skipping of the hard stop when encountering a severe error.
